### PR TITLE
Removing warning for long pages - not tested

### DIFF
--- a/includes/EditPage.php
+++ b/includes/EditPage.php
@@ -976,12 +976,7 @@ class EditPage {
 		}
 		if ( $this->tooBig || $this->kblength > $wgMaxArticleSize ) {
 			$wgOut->addWikiText( wfMsg( 'longpageerror', $wgLang->formatNum( $this->kblength ), $wgMaxArticleSize ) );
-		} 
-		/* Uncomment to show a warning for pages longer than 29 kb
-		elseif( $this->kblength > 29 ) {
-			$wgOut->addWikiText( wfMsg( 'longpagewarning', $wgLang->formatNum( $this->kblength ) ) );
 		}
-		 */
 
 		$rows = $wgUser->getIntOption( 'rows' );
 		$cols = $wgUser->getIntOption( 'cols' );


### PR DESCRIPTION
Per the discussion on http://www.werelate.org/wiki/WeRelate_talk:Watercooler#Warning_notice_on_place_pages_.5B9_June_2014.5D, I commented out the code that gives a longpagewarning message.

I don't have WeRelate built locally right now, so I haven't tested it, but it looks like this should fix it. :)
