### PR TITLE
Default number of rows for “What links here” to 500

### DIFF
--- a/includes/SpecialWhatlinkshere.php
+++ b/includes/SpecialWhatlinkshere.php
@@ -32,7 +32,7 @@ class WhatLinksHerePage {
 
 		$this->limit = min( $this->request->getInt( 'limit', 50 ), 5000 );
 		if ( $this->limit <= 0 ) {
-			$this->limit = 50;
+			$this->limit = 500;
 		}
 		$this->from = $this->request->getText( 'from' );
 		$this->dir = $this->request->getText( 'dir', 'next' );


### PR DESCRIPTION
This change incorporates the request from the WeRelate:Request List, named "Number of rows for 'What links here'".

_From the WeRelate:Request List page (2 Aug 2017):_
Minimum functionality
Set the default number of rows to display on a “What links here” page to 500.