### PR TITLE
fix defect in Place.php

### DIFF
--- a/extensions/structuredNamespaces/Place.php
+++ b/extensions/structuredNamespaces/Place.php
@@ -1197,6 +1197,14 @@ END;
 
       // $priority includes $numSpaces from parent places, which it shouldn't
 		$parents = Place::placeAbbrevsGetParents($locatedIn);
+    if ( count($parents) === 0 ) {
+      $numSpaces = substr_count($prefName, ' ');
+      Place::placeAbbrevsInsertAbbrevs($prefName, $prefName, null, $titleString, $wlh + $numSpaces, $latitude, $longitude);
+	   	foreach ($altNames as $altName) {
+        $numSpaces = substr_count($altName, ' ');
+		    Place::placeAbbrevsInsertAbbrevs($altName, $prefName, null, $titleString, $wlh + $numSpaces + 14, $latitude, $longitude);
+		   }
+    }
 		foreach ($parents as $parentName => $priority) {
          $numSpaces = substr_count($prefName, ' ');
    		Place::placeAbbrevsInsertAbbrevs($prefName, $prefName, $parentName, $titleString, $wlh + $numSpaces + $priority + 10, $latitude, $longitude);


### PR DESCRIPTION
Previously, if you created a new place with no parent, nothing was added to place_abbrevs table. This fix ensures that a record is added (as well as records for alt names).