### PR TITLE
Decommission FTE; Tweaks to copy/paste source

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -326,6 +326,7 @@ require_once("$IP/extensions/familytree/SpecialShowFamilyTree.php");
 require_once("$IP/extensions/familytree/SpecialTreeRelated.php");
 require_once("$IP/extensions/familytree/SpecialTreeDeletionImpact.php");
 require_once("$IP/extensions/familytree/SpecialTreeCountWatchers.php");
+require_once("$IP/extensions/familytree/SpecialCopyTree.php");
 require_once("$IP/extensions/gedcom/GedcomAjaxFunctions.php");
 require_once("$IP/extensions/gedcom/SpecialGedcomPage.php");
 require_once("$IP/extensions/gedcom/SpecialGedcoms.php");

--- a/extensions/familytree/FamilyTreeAjaxFunctions.php
+++ b/extensions/familytree/FamilyTreeAjaxFunctions.php
@@ -196,7 +196,7 @@ function wfCopyFamilyTree($args) {
 	global $wgAjaxCachePolicy, $wgUser;
 
    // set cache policy
-	$wgAjaxCachePolicy->setPolicy(0);
+	//$wgAjaxCachePolicy->setPolicy(0);   // commented out Dec 2020 by Janet Bjorndahl (failed when calling from new Copy Tree wiki page)
 
 	// validate input arguments
    $status = FTE_SUCCESS;

--- a/extensions/familytree/SpecialCopyTree.php
+++ b/extensions/familytree/SpecialCopyTree.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ *
+ * @package MediaWiki
+ * @subpackage SpecialPage
+ */
+
+# Register with MediaWiki as an extension
+$wgExtensionFunctions[] = "wfSpecialCopyTreeSetup";
+
+function wfSpecialCopyTreeSetup() {
+  global $wgMessageCache, $wgSpecialPages, $wgParser;
+  $wgMessageCache->addMessages( array( "copytree" => "Copy Tree" ) );
+  $wgSpecialPages['CopyTree'] = array('SpecialPage','CopyTree');
+}
+
+function wfSpecialCopyTree() {
+  global $wgOut, $wgRequest, $wgUser, $wgCommandLineMode, $wgLang;
+
+  // Get user and name of tree to copy
+  $user = $wgRequest->getVal('user');
+  $name = $wgRequest->getVal('name');
+
+  if (!$wgUser->isLoggedIn()) {
+		if( !$wgCommandLineMode && !isset( $_COOKIE[session_name()] )  ) {
+			User::SetupSession();
+		}
+		$request = new FauxRequest(array('returnto' => 'User:' . $user));
+		require_once('includes/SpecialUserlogin.php');
+		$form = new LoginForm($request);
+		$form->mainLoginForm("You need to log in to copy trees<br/><br/>", '');
+		return;
+	}
+	if( $wgUser->isBlocked() ) {
+		$wgOut->blockedPage();
+		return;
+	}
+	if( wfReadOnly() ) {
+		$wgOut->readOnlyPage();
+		return;
+	}
+
+  // Get user and name of tree to create
+  $newUser = $wgUser->getName();
+  $newName = $wgRequest->getVal('newtree');
+  
+  // If user has already entered the tree name, copy the tree and display message. Else display the input form.
+  $wgOut->setPagetitle("Copy Tree");
+  if ( $newName ) {
+    $status = wfCopyFamilyTree("user=$user|name=$name|newuser=$newUser|newname=$newName");
+    if ($status != '<copy status="' . FTE_SUCCESS . '"></copy>') {
+      $msg = htmlspecialchars("Error copying tree $user/$name");
+    }
+	  else {
+      $msg = htmlspecialchars("Tree $user/$name is being copied to $newUser/$newName");
+	  }
+	  $wgOut->addHTML( "<p><font size=\"+1\" color=\"red\">$msg</font></p>\n");
+  }
+  else {
+	  $formHtml = '<form method="get" action="/wiki/Special:CopyTree">';
+    $formHtml .= '<input type = "hidden" name="user" value="' . $user . '"/>';
+    $formHtml .= '<input type = "hidden" name="name" value="' . $name . '"/>';
+    $formHtml .= '<label for="newtree">Name of new tree </label><input type="text" id="newtree" name="newtree"/></form>';
+    $wgOut->addHTML($formHtml);
+  }
+}
+?>

--- a/extensions/other/SpecialDashboard.php
+++ b/extensions/other/SpecialDashboard.php
@@ -225,9 +225,9 @@ END;
 		$familyTrees = FamilyTreeUtil::getFamilyTrees($wgUser->getName(), true, $dbr);  // changed Sep 2020 by Janet Bjorndahl
       foreach($familyTrees as $familyTree) {
       	$ret .= '<li>' . htmlspecialchars($familyTree['name']) . ' (&nbsp;' .
-					$skin->makeKnownLinkObj(Title::makeTitle(NS_SPECIAL, 'Search'), 'view', 'k='.urlencode('+Tree:"'.$wgUser->getName().'/'.$familyTree['name'].'"')) .
-					'&nbsp;) (&nbsp;' .
-					'<a href="/fte/index.php?userName='. urlencode($wgUser->getName()) . '&treeName=' . urlencode($familyTree['name']) . '">launch FTE</a>&nbsp;)';
+					$skin->makeKnownLinkObj(Title::makeTitle(NS_SPECIAL, 'Search'), 'search', 'k='.urlencode('+Tree:"'.$wgUser->getName().'/'.$familyTree['name'].'"')) .  // link renamed Dec 2020
+					'&nbsp;)';
+//					'<a href="/fte/index.php?userName='. urlencode($wgUser->getName()) . '&treeName=' . urlencode($familyTree['name']) . '">launch FTE</a>&nbsp;)';   removed Dec 2020
         // Allow user to explore a tree only if the tree has at least one page, because exploring starts with displaying a page (added Sep 2020 by Janet Bjorndahl)     
         if ($familyTree['count'] > 0) { 
           $explore = $skin->makeKnownLinkObj(SpecialTrees::getExploreFirstTitle($wgUser->getName(), $familyTree['name']), 'explore', 

--- a/extensions/structuredNamespaces/Family.php
+++ b/extensions/structuredNamespaces/Family.php
@@ -666,7 +666,7 @@ END;
 
 		// add javascript functions
       $wgOut->addScript("<script type=\"text/javascript\" src=\"$wgScriptPath/jquery.tablednd_0_5.yui.1.js\"></script>");
-      $wgOut->addScript("<script type=\"text/javascript\" src=\"$wgScriptPath/personfamily.36.js\"></script>");
+      $wgOut->addScript("<script type=\"text/javascript\" src=\"$wgScriptPath/personfamily.37.js\"></script>");
 		$wgOut->addScript("<script type=\"text/javascript\" src=\"$wgScriptPath/autocomplete.10.js\"></script>");
 
 		$tm = new TipManager();

--- a/extensions/structuredNamespaces/Person.php
+++ b/extensions/structuredNamespaces/Person.php
@@ -1294,7 +1294,7 @@ END;
 
 		// add javascript functions
       $wgOut->addScript("<script type=\"text/javascript\" src=\"$wgScriptPath/jquery.tablednd_0_5.yui.1.js\"></script>");
-      $wgOut->addScript("<script type=\"text/javascript\" src=\"$wgScriptPath/personfamily.36.js\"></script>");
+      $wgOut->addScript("<script type=\"text/javascript\" src=\"$wgScriptPath/personfamily.37.js\"></script>");
 		$wgOut->addScript("<script type=\"text/javascript\" src=\"$wgScriptPath/autocomplete.10.js\"></script>");
 
 		$tm = new TipManager();

--- a/extensions/structuredNamespaces/UserPage.php
+++ b/extensions/structuredNamespaces/UserPage.php
@@ -158,16 +158,6 @@ class UserPage extends StructuredData {
         return '';
     }
 
-    // This function is no longer used - the code is handled inline below
-    protected function formatFamilyTree($value, $dummy) {
-    	 global $wrHostName;
-       return $value['name'].' <span class="plainlinks">'
-              . ' ([http://'.$wrHostName.'/wiki/Special:Search?k='. urlencode('+Tree:"'.$this->userName.'/'.$value['name'].'"') . " view])"
-              . ' ([http://'.$wrHostName.'/fte/index.php?userName='. urlencode($this->userName) . '&treeName=' . urlencode($value['name']) . " launch FTE])"
-//              . "</span><dd><small>{$this->userName} last opened: " . date("d M Y",wfTimestamp(TS_UNIX,$value['timestamp'])) . " people: {$value['count']}</small>";
-              . "</span><dd><small>people: {$value['count']}</small>";
-    }
-
     private function getPersonalResearchPages() {
        $prps = array();
 
@@ -283,14 +273,16 @@ class UserPage extends StructuredData {
           $n=0;
           foreach ($familyTrees as $familyTree) {
             $values[$n] = '<dl><dt>'.$familyTree['name'].' <span class="plainlinks">'
-                   . ' ([http://'.$wrHostName.'/wiki/Special:Search?k='. urlencode('+Tree:"'.$this->userName.'/'.$familyTree['name'].'"') . " view])"
-                   . ' ([http://'.$wrHostName.'/fte/index.php?userName='. urlencode($this->userName) . '&treeName=' . urlencode($familyTree['name']) . " launch FTE])";
+                   . ' ([http://'.$wrHostName.'/wiki/Special:Search?k='. urlencode('+Tree:"'.$this->userName.'/'.$familyTree['name'].'"') . " search])";  // link renamed Dec 2020
+//                   . ' ([http://'.$wrHostName.'/fte/index.php?userName='. urlencode($this->userName) . '&treeName=' . urlencode($familyTree['name']) . " launch FTE])";  removed Dec 2020
             if ( $familyTree['count'] > 0 ) { // Add explore link, but only for trees with at least one page (added Sep 2020 by Janet Bjorndahl)
               $firstTitle = SpecialTrees::getExploreFirstTitle($this->userName, $familyTree['name']);
-              $values[$n] .= ' ([http://'.$wrHostName.'/w/index.php?title=' . $firstTitle->getPrefixedURL(). '&mode=explore&user=' . $this->userName. '&tree=' . $familyTree['name'] 
-                      . '&liststart=0&listrows=20 explore])';
+              $values[$n] .= ' ([http://'.$wrHostName.'/w/index.php?title=' . $firstTitle->getPrefixedURL(). '&mode=explore&user=' . $this->userName. '&tree='
+                      . str_replace(' ','+',$familyTree['name']) . '&liststart=0&listrows=20 explore])';   // bug fixed Dec 2020
+              $values[$n] .= ' ([http://'.$wrHostName.'/w/index.php?title=Special:CopyTree&user=' . $this->userName
+                      . '&name=' . str_replace(' ','+',$familyTree['name']) . ' copy])';   // added Dec 2020 
             }
-            $values[$n++] .= "</span><dd>people: {$familyTree['count']}</dl>";
+            $values[$n++] .= "</span><dd>pages: {$familyTree['count']}</dl>";     // renamed from people to pages Dec 2020 by Janet Bjorndahl
           }
           $familyTrees = $this->getLV('Family Trees', $values);
 

--- a/skins/MonoBook.php
+++ b/skins/MonoBook.php
@@ -324,8 +324,7 @@ END;
             'userprofile' => ($wgUser->isLoggedIn() ? 'User:' . urlencode($wgUser->getName()) : 'Special:Userlogin'),
             'talkpage' => ($wgUser->isLoggedIn() ? 'User_talk:' . urlencode($wgUser->getName()) : 'Special:Userlogin'), 
             'trees' => 'Special:Trees',
-            'showduplicates' => ($wgUser->isLoggedIn() ? 'Special:ShowDuplicates/' . urlencode($wgUser->getName()) : 'Special:Userlogin'), 
-            '-launchfte' => $wrProtocol.'://www.werelate.org/fte'
+            'showduplicates' => ($wgUser->isLoggedIn() ? 'Special:ShowDuplicates/' . urlencode($wgUser->getName()) : 'Special:Userlogin')  // Launch FTE removed Dec 2020 
         ),
         'admin' => array(
             'recentchanges' => 'Special:Recentchanges',


### PR DESCRIPTION
Removed FTE menu item and links.
Some minor changes related to decommission FTE (e.g., changed email link, renamed "view" to "search", allow copy tree from User page).
3 minor improvements to copy/paste source functionality.
