### PR TITLE
DateHandler changes

### DIFF
--- a/extensions/other/GetTreeData.php
+++ b/extensions/other/GetTreeData.php
@@ -195,7 +195,7 @@ class TreeData {
 
          // populate data
          list($marriageYear, $marriageDate, $marriagePlace, $eventTypeIndex) = $this->getEventData($xml, array('Marriage'));
-         $marriageDate = DateHandler::formatDate($marriageDate);              // added Nov 2020 by Janet Bjorndahl
+         $marriageDate = DateHandler::formatDate($marriageDate, true);              // added Nov 2020 by Janet Bjorndahl; true added Mar 2021 JB
          $thumbURL = $this->getPrimaryImage($xml, false);
          $data = array();
          $data['url'] = $family->getTitle()->getFullURL();

--- a/extensions/structuredNamespaces/DateHandler.php
+++ b/extensions/structuredNamespaces/DateHandler.php
@@ -41,9 +41,9 @@ abstract class DateHandler {
                                            
   private static $ORDINAL_SUFFIXES = array('st', 'nd', 'rd', 'th');            // added Feb 2021 by Janet Bjorndahl                               
 
-  public static function formatDate($date) {
+  public static function formatDate($date, $discreteEvent=false) {             // added discreteEvent Mar 2021 by Janet Bjorndahl
     $formatedDate = $languageDate = '';
-    if ( self::editDate($date, $formatedDate, $languageDate) === true ) {
+    if ( self::editDate($date, $formatedDate, $languageDate, $discreteEvent) === true ) {
       return $languageDate;
     }
     else {
@@ -51,9 +51,9 @@ abstract class DateHandler {
     }
   }
 
-  public static function formatDateEnglish($date) {
+  public static function formatDateEnglish($date, $discreteEvent=false) {      // added discreteEvent Mar 2021 by Janet Bjorndahl
     $formatedDate = $languageDate = '';
-    if ( self::editDate($date, $formatedDate, $languageDate) === true ) {
+    if ( self::editDate($date, $formatedDate, $languageDate, $discreteEvent) === true ) {
       return $formatedDate;
     }
     else {
@@ -65,9 +65,8 @@ abstract class DateHandler {
     $parsedDate = array();
     $formatedDate = '';
     $languageDate = '';
-    
+
     $parsedDate=self::parseDate($date);
-    
     // Check for some overall errors and do a few fixes before dealing with each part of the parsed date
     if ( isset($parsedDate['message']) ) {                             // if parsing was unsuccessful, return the message
       return $parsedDate['message'];
@@ -175,7 +174,6 @@ abstract class DateHandler {
       $formatedDate .= ($formatedDate == '' ? $parsedDate['text'] : ' ' . $parsedDate['text']);
       $languageDate .= ($languageDate == '' ? $parsedDate['text'] : ' ' . $parsedDate['text']);
     }
-
     // If reformating details requested and there are any, return that information (added Mar 2021 by Janet Bjorndahl)
     if ( $reformatDetails && isset($parsedDate['reformat']) ) {
       return $parsedDate['reformat'];
@@ -470,16 +468,16 @@ abstract class DateHandler {
     $fields = array();              // reinitialize fields (used again below)
     }
     
-    // If date includes a dash, replace with "to" or "and" depending on whether the string already has "from/est" or "bet".
-    // If it has neither, treat as bet/and (applicable to all types of events).
+    // If date includes a dash, replace with "and" if it already has "bet", "btw" or "between".        Changed Mar 2021 by Janet Bjorndahl
+    // Otherwise, treat as from/to (editDate will correct to bet/and for discrete event types).
     if ( strpos($date, '-') ) {
-      if ( strpos($date, 'from' ) !== false || strpos($date, 'est' ) !== false ) {
-        $date = str_replace('-', ' to ', $date);
+      if ( strpos($date, 'bet') !== false || strpos($date, 'btw') !== false || strpos($date, 'between') !== false ) {
+        $date = str_replace('-', ' and ', $date);
       }
       else { 
-        $date = str_replace('-', ' and ', $date);
-        if ( strpos($date, 'bet' ) === false ) {
-          $date = 'bet ' . $date;
+        $date = str_replace('-', ' to ', $date);
+        if ( strpos($date, 'from') === false && strpos($date, 'frm') === false ) {
+          $date = 'from ' . $date;
         }
       }
       $parsedDate['reformat'] = 'Significant reformat';          // added Mar 2021 by Janet Bjorndahl

--- a/extensions/structuredNamespaces/ESINHandler.php
+++ b/extensions/structuredNamespaces/ESINHandler.php
@@ -44,10 +44,11 @@ class ESINHandler extends StructuredData {
 	);
 
   // DISCRETE_EVENT added (to support date editing) Oct 2020 by Janet Bjorndahl ('Census', 'Obituary', 'Estate Settlement' removed Mar 2021 by Janet Bjorndahl)
+  // ('Probate' removed and marriage events added Mar 2021 by Janet Bjorndahl)
   private static $DISCRETE_EVENT = array ('Birth', 'Christening', 'Death', 'Burial', 'Alt Birth', 'Alt Christening', 'Alt Death', 'Alt Burial',
       'Adoption', 'Baptism', 'Bar Mitzvah', 'Bat Mitzvah', 'Blessing', 'Confirmation', 'Cremation', 'Degree', 'Emigration',
-      'First Communion', 'Funeral', 'Graduation', 'Immigration', 'Naturalization', 'Ordination', 'Probate', 'Stillborn', 'Will',
-      'Estate Inventory'); 
+      'First Communion', 'Funeral', 'Graduation', 'Immigration', 'Naturalization', 'Ordination', 'Stillborn', 'Will', 'Estate Inventory',
+      'Marriage', 'Alt Marriage', 'Marriage License', 'Marriage Bond', 'Marriage Contract', 'Divorce Filing', 'Divorce', 'Annulment'); 
       
   // Event type arrays added (to support event sorting) Oct 2020 by Janet Bjorndahl 
   private static $PERSON_EVENT_TYPES = array('Birth'=>'0010', 'Alt Birth'=>'0020', 'Christening'=>'0030',  'Alt Christening'=>'0040', 
@@ -250,22 +251,22 @@ class ESINHandler extends StructuredData {
       $birthDate = $birthPlace = $deathDate = $deathPlace = '';
       if ((string)$p['birthdate'] || (string)$p['birthplace']) {
          $birthLabel = 'b. ';
-         $birthDate = DateHandler::formatDate((string)$p['birthdate']);        // formating call added Nov 2020 by Janet Bjorndahl
+         $birthDate = DateHandler::formatDate((string)$p['birthdate'],true);        // formating call added Nov 2020 by Janet Bjorndahl; true added Mar 2021 by JB
          $birthPlace = (string)$p['birthplace'];
       }
       else if ((string)$p['chrdate'] || (string)$p['chrplace']) {
          $birthLabel = 'chr. ';
-         $birthDate = DateHandler::formatDate((string)$p['chrdate']);          // formating call added Nov 2020 by Janet Bjorndahl
+         $birthDate = DateHandler::formatDate((string)$p['chrdate'],true);          // formating call added Nov 2020 by Janet Bjorndahl; true added Mar 2021 by JB
          $birthPlace = (string)$p['chrplace'];
       }
       if ((string)$p['deathdate'] || (string)$p['deathplace']) {
          $deathLabel = 'd. ';
-         $deathDate = DateHandler::formatDate((string)$p['deathdate']);        // formating call added Nov 2020 by Janet Bjorndahl
+         $deathDate = DateHandler::formatDate((string)$p['deathdate'],true);        // formating call added Nov 2020 by Janet Bjorndahl; true added Mar 2021 by JB
          $deathPlace = (string)$p['deathplace'];
       }
       else if ((string)$p['burialdate'] || (string)$p['burialplace']) {
          $deathLabel = 'bur. ';
-         $deathDate = DateHandler::formatDate((string)$p['burialdate']);       // formating call added Nov 2020 by Janet Bjorndahl
+         $deathDate = DateHandler::formatDate((string)$p['burialdate'],true);       // formating call added Nov 2020 by Janet Bjorndahl; true added Mar 2021 by JB
          $deathPlace = (string)$p['burialplace'];
       }
       if ($birthPlace) $birthPlace = '[[Place:' . StructuredData::addBarToTitle($birthPlace) . ']]';
@@ -734,7 +735,7 @@ END;
 //      $notes = StructuredData::formatAsLinks((string)@$eventFact['notes']);
 //      $images = StructuredData::formatAsLinks((string)@$eventFact['images']);
       $type = (string)$eventFact['type'];
-      $date = DateHandler::formatDate((string)$eventFact['date']);                             // added Nov 2020 by Janet Bjorndahl
+      $date = DateHandler::formatDate((string)$eventFact['date'], in_array($type, ESINHandler::$DISCRETE_EVENT));         // added Nov 2020 by Janet Bjorndahl; discrete parm added Mar 2021 JB
       $place = (string)$eventFact['place'];
       if ($place) {
          $place = '[[Place:' . StructuredData::addBarToTitle($place) . ']]';

--- a/extensions/structuredNamespaces/Family.php
+++ b/extensions/structuredNamespaces/Family.php
@@ -343,7 +343,7 @@ END;
          if (isset($xml->event_fact)) {
             foreach ($xml->event_fact as $eventFact) {
                if ($eventFact['type'] == 'Marriage') {
-                  $marriageDate = (string)@$eventFact['date'];
+                  $marriageDate = DateHandler::formatDate((string)@$eventFact['date'],true);    // formatDate call added Mar 2021 by Janet Bjorndahl
                   $marriagePlace = (string)@$eventFact['place'];
                }
             }
@@ -450,7 +450,7 @@ END;
             foreach ($this->xml->event_fact as $eventFact) {
                if ($eventFact['type'] == 'Marriage') {
                   $marriageFound = true;
-                  $marriageDate = (string)$eventFact['date'];
+                  $marriageDate = DateHandler::formatDate((string)$eventFact['date'],true);    // formatDate call added Mar 2021 by Janet Bjorndahl
                   $marriagePlace = $this->getPlace($eventFact);
                }
             }

--- a/extensions/structuredNamespaces/Person.php
+++ b/extensions/structuredNamespaces/Person.php
@@ -463,7 +463,7 @@ class Person extends StructuredData {
             if (isset($familyXml->event_fact)) {
                foreach ($familyXml->event_fact as $eventFact) {
                   if ((string)$eventFact['type'] == 'Marriage') {
-                     $marriageDate = DateHandler::formatDate((string)$eventFact['date']);    // formatDate call added Nov 2020 by Janet Bjorndahl
+                     $marriageDate = DateHandler::formatDate((string)$eventFact['date'], true);    // formatDate call added Nov 2020 by Janet Bjorndahl; true added Mar 2021 JB
                      $marriageKey = DateHandler::getDateKey($marriageDate, true);  // changed to DateHandler function Oct 2020 by Janet Bjorndahl
                      $marriage = "<div class=\"wr-infobox-event\">m. <span class=\"wr-infobox-date\">$marriageDate</span></div>";
                   }
@@ -661,24 +661,24 @@ END;
             foreach ($this->xml->event_fact as $eventFact) {
                if ($eventFact['type'] == 'Birth') {
                   $birthFound = true;
-                  $birthDate = DateHandler::formatDate((string)$eventFact['date']);        // formatDate call added Nov 2020 by Janet Bjorndahl
+                  $birthDate = DateHandler::formatDate((string)$eventFact['date'],true);        // formatDate call added Nov 2020 by Janet Bjorndahl; true added Mar 2021 JB
                   $birthPlace = (string)$eventFact['place'];
                   $birthSource = (string)$eventFact['sources'];
                }
                else if ($eventFact['type'] == 'Christening' || $eventFact['type'] == 'Baptism') {
                   $chrFound = true;
-                  $chrDate = DateHandler::formatDate((string)$eventFact['date']);          // formatDate call added Nov 2020 by Janet Bjorndahl
+                  $chrDate = DateHandler::formatDate((string)$eventFact['date'],true);          // formatDate call added Nov 2020 by Janet Bjorndahl; true added Mar 2021 JB
                   $chrPlace = (string)$eventFact['place'];
                }
                else if ($eventFact['type'] == 'Death') {
                   $deathFound = true;
-                  $deathDate = DateHandler::formatDate((string)$eventFact['date']);        // formatDate call added Nov 2020 by Janet Bjorndahl
+                  $deathDate = DateHandler::formatDate((string)$eventFact['date'],true);        // formatDate call added Nov 2020 by Janet Bjorndahl; true added Mar 2021 JB
                   $deathPlace = (string)$eventFact['place'];
                   $deathSource = (string)$eventFact['sources'];
                }
                else if ($eventFact['type'] == 'Burial') {
                   $burFound = true;
-                  $burDate = DateHandler::formatDate((string)$eventFact['date']);          // formatDate call added Nov 2020 by Janet Bjorndahl
+                  $burDate = DateHandler::formatDate((string)$eventFact['date'],true);          // formatDate call added Nov 2020 by Janet Bjorndahl; true added Mar 2021 JB
                   $burPlace = (string)$eventFact['place'];
                }
             }


### PR DESCRIPTION
Change default for interpreting a dash to be "from/to" instead of "bet/and". Add the "discrete event" parameter to several calls so that discrete events are set to "bet/and". Remove "Probate" from list of discrete events and add marriage events.