### PR TITLE
Fixed marriage display bug; fixed family tree date display

### DIFF
--- a/extensions/other/GetTreeData.php
+++ b/extensions/other/GetTreeData.php
@@ -308,8 +308,8 @@ class TreeData {
       }
       $fullname = StructuredData::getFullname($member);
       $birthDate = (string)$member['birthdate'] ? (string)$member['birthdate'] : (string)$member['chrdate'];
-      $beginYear = DateHandler::getYear($birthDate, true);       // changed to DateHandler function Oct 2020 by Janet Bjorndahl
-      $endYear = DateHandler::getYear((string)$member['deathdate'] ? (string)$member['deathdate'] : (string)$member['burialdate'], true);
+      $beginYear = DateHandler::getYear($birthDate, true, true);                     // changed to DateHandler function Oct 2020 by Janet Bjorndahl; 3rd parm added Mar 2021
+      $endYear = DateHandler::getYear((string)$member['deathdate'] ? (string)$member['deathdate'] : (string)$member['burialdate'], true, true);   // 3rd parm added Mar 2021
       if ($beginYear || $endYear) {
          $yearrange = "$beginYear - $endYear";
       }

--- a/extensions/structuredNamespaces/Person.php
+++ b/extensions/structuredNamespaces/Person.php
@@ -481,9 +481,11 @@ class Person extends StructuredData {
             }
             // If there is a spouse but no family events, create a dummy event so that it shows up in the Facts and Events section.  Added Mar 2021 by Janet Bjorndahl
             else {
-              $marriageEvents[] = array('type' => 'Marriage', 'date' => '',
-                        'place' => '', 'desc' => @Family::$EVENT_CONJUNCTIONS['Marriage'] . ' ' . join(' or ',$spouseLinks),
-                        'srcs' => '', 'no_citation_needed' => true);
+              if (!$isParentsSiblings) {
+                $marriageEvents[] = array('type' => 'Marriage', 'date' => '',
+                          'place' => '', 'desc' => @Family::$EVENT_CONJUNCTIONS['Marriage'] . ' ' . join(' or ',$spouseLinks),
+                          'srcs' => '', 'no_citation_needed' => true);
+              }
             }            
             foreach ($familyXml->child as $child) {
                $children .= $this->getFamilyMember($child, $childLabel, false, $spouseLinks);


### PR DESCRIPTION
Fixed recently introduced bug in displaying marriages when there is no event.
Found one more place to fix display of dates - family popup in the family tree.