### PR TITLE
tighter "living person" edit

### DIFF
--- a/extensions/structuredNamespaces/DateHandler.php
+++ b/extensions/structuredNamespaces/DateHandler.php
@@ -169,6 +169,22 @@ abstract class DateHandler {
         return 'Invalid date range';
       }  
     }
+    
+    // Future dates are not allowed (added Jul 2021 by Janet Bjorndahl)
+    $today = date_create('',timezone_open('Pacific/Auckland'));   // Use New Zealand time because New Zealand is unlikely to change to other side of International Date Line.
+    $thisYear = (int)$today->format("Y");
+    $thisMonth = (int)$today->format("m");
+    $thisDay = (int)$today->format("d");
+    for ($i=0; $i<=1; $i++) {
+      if ( (isset($parsedDate['effyear'][$i]) && (int)$parsedDate['effyear'][$i] > $thisYear) ||
+           (isset($parsedDate['month'][$i]) && (int)$parsedDate['effyear'][$i] == $thisYear && self::getMonthNumber($parsedDate['month'][$i]) > $thisMonth) || 
+           (isset($parsedDate['day'][$i]) && (int)$parsedDate['effyear'][$i] == $thisYear && self::getMonthNumber($parsedDate['month'][$i]) == $thisMonth && 
+                 (int)$parsedDate['day'][$i] > $thisDay) ) {
+        $formatedDate = '';
+        $languageDate = '';
+        return 'Future date';
+      }
+    }
 
     if ( isset($parsedDate['text']) ) {
       $formatedDate .= ($formatedDate == '' ? $parsedDate['text'] : ' ' . $parsedDate['text']);

--- a/extensions/structuredNamespaces/ESINHandler.php
+++ b/extensions/structuredNamespaces/ESINHandler.php
@@ -133,6 +133,8 @@ class ESINHandler extends StructuredData {
    public static function isLivingDates($birthDate, $chrDate,
                                         $deathDate=null, $deathPlace=null, $deathDesc=null,
                                         $burDate=null, $burPlace=null, $burDesc=null) {
+
+      /* Having anything (besides 'living' or 'private') in death/burial fields is no longer sufficient to establish that a person is deceased (Jul 2021 Janet Bjorndahl) 
       if (ESINHandler::isNonLivingValue($deathDate) ||
           ESINHandler::isNonLivingValue($deathPlace) ||
           ESINHandler::isNonLivingValue($deathDesc) ||
@@ -141,6 +143,27 @@ class ESINHandler extends StructuredData {
           ESINHandler::isNonLivingValue($burDesc)) {
          return false;
       }
+      */
+
+      /* To establish that a person is deceased requires a valid death or burial date not using the "aft"  or "est" modifier
+         and not completely within parentheses unless "(in infancy)" or "(young)".                                           New rule Jul 2121 - Janet Bjorndahl
+         Famous people are exempt from the living persons rule. */
+      $formatedDate = $languageDate = '';
+      if ( stripos($deathDate,'aft')===false && stripos($deathDate,'est')===false ) {
+         if ( DateHandler::editDate($deathDate, $formatedDate, $languageDate, true, false) === true && 
+               $formatedDate!='' && (stripos($formatedDate, '(')!==0 || stripos($formatedDate,'(in infancy)')!==false || stripos($formatedDate,'(young)')!==false) ) {
+            return false;
+         }
+      }
+      if ( stripos($burDate,'aft')===false && stripos($burDate,'est')===false ) {
+         if ( DateHandler::editDate($burDate, $formatedDate, $languageDate, true, false) === true &&
+               $formatedDate!='' && stripos($formatedDate, '(')!==0 ) {
+            return false;
+         }
+      }
+      if ( stripos($deathDesc,'{{FamousLivingPersonException')!==false )
+         return false;
+           
       $birthYear = DateHandler::getEffectiveYear($birthDate);       // changed to new DateHandler function Oct 2020 by Janet Bjorndahl
       $chrYear = DateHandler::getEffectiveYear($chrDate);
       return ($birthYear && (int)date("Y") - (int)$birthYear < 110) || (!$birthYear && $chrYear && (int)date("Y") - (int)$chrYear < 110);


### PR DESCRIPTION
Treat a future date as an error (show an error message but don't require it to be fixed before saving the page - same as most date errors for now).
If born in last 110 years, require one of the following to save the page:
- valid death or burial date, excluding a date using "aft" or "est" modifier
- death date of "(in infancy)" or "(young)"
- famous living person exception template