### PR TITLE
require user to fix invalid dates; message for events out of order

### DIFF
--- a/extensions/gedcom/GedcomAjaxFunctions.php
+++ b/extensions/gedcom/GedcomAjaxFunctions.php
@@ -1039,8 +1039,11 @@ function wfAddPage($args) {
          if (ESINHandler::isLivingDates($args['bd'], null, $args['dd'], $args['dp'])) {
             $error = 'Living people cannot be added to WeRelate. People born in the last 110 years must have a death date';
          }
-         else if (ESINHandler::isAmbiguousDate($args['bd']) || ESINHandler::isAmbiguousDate($args['dd'])) {
-            $error = "Please write dates in D MMM YYYY format so they are unambiguous (ie 5 Jan 1900)";
+//         else if (ESINHandler::isAmbiguousDate($args['bd']) || ESINHandler::isAmbiguousDate($args['dd'])) {
+//            $error = "Please write dates in D MMM YYYY format so they are unambiguous (ie 5 Jan 1900)";
+         // All invalid dates must be fixed (not just ambiguous ones); changed Nov 2021 by Janet Bjorndahl
+         else if (ESINHandler::isInvalidDate($args['bd']) || ESINHandler::isInvalidDate($args['dd'])) {
+            $error = "Please correct date(s); they should be in D MMM YYYY format.";
          }
          else {
             if (!$title) $title = StructuredData::constructPersonTitle($args['g'], $args['s']);
@@ -1077,8 +1080,11 @@ function wfAddPage($args) {
          }
 		}
 		else if ($ns == NS_FAMILY) {
-         if (ESINHandler::isAmbiguousDate($args['md'])) {
-            $error = "Please write dates in D MMM YYYY format so they are unambiguous (ie 5 Jan 1900)";
+//         if (ESINHandler::isAmbiguousDate($args['md'])) {
+//            $error = "Please write dates in D MMM YYYY format so they are unambiguous (ie 5 Jan 1900)";
+         // All invalid dates must be fixed (not just ambiguous ones); changed Nov 2021 by Janet Bjorndahl
+         if (ESINHandler::isInvalidDate($args['md'])) {
+            $error = "Please correct date; it should be in D MMM YYYY format.";
          }
          else {
             $title = StructuredData::constructFamilyTitle($args['hg'], $args['hs'], $args['wg'], $args['ws']);

--- a/extensions/structuredNamespaces/Person.php
+++ b/extensions/structuredNamespaces/Person.php
@@ -1357,8 +1357,14 @@ END;
 	   if (!$this->isGedcomPage && (StructuredData::titlesMissingId($spouseOfFamilies) || !StructuredData::titlesExist(NS_FAMILY, $spouseOfFamilies))) {
    		$result .= "<p><font color=red>Spouse family page not found; please remove it, save this page, then add a new one</font></p>";
 	   }
-     if (ESINHandler::hasAmbiguousDates($this->xml)) {
-       $result .= "<p><font color=red>Please write dates in \"<i>D MMM YYYY</i>\" format so they are unambiguous (ie 5 Jan 1900)</font></p>";
+//     if (ESINHandler::hasAmbiguousDates($this->xml)) {
+//       $result .= "<p><font color=red>Please write dates in \"<i>D MMM YYYY</i>\" format so they are unambiguous (ie 5 Jan 1900)</font></p>";
+//   Message for all date errors (not just ambiguous ones) - changed Nov 2021 by Janet Bjorndahl
+     if (ESINHandler::hasInvalidDates($this->xml)) {
+       $result .= "<p><font color=red>Please correct invalid dates. Dates should be in \"<i>D MMM YYYY</i>\" format (ie 5 Jan 1900) with optional modifiers (eg, bef, aft).</font></p>";
+     }
+     if (ESINHandler::hasEventsOutOfOrder($this)) {                                                  // added Nov 2021 by Janet Bjorndahl
+       $result .= "<p><font color=red>Warning: Events are out of order. Please correct date(s) if you can.</font></p>";
      }
      if (ESINHandler::hasReformatedDates($this->xml)) {                                              // added Nov 2020 by Janet Bjorndahl
        $result .= "<p><font color=red>One or more dates was changed to WeRelate standard. Please compare to original value to ensure no loss of meaning. If the standard date is OK, no further action is required - you may save the page.</font></p>";
@@ -1545,7 +1551,9 @@ END;
 		 if (!StructuredData::titleStringHasId($this->titleString)) {
 		 	return false;
 		 }
-     if (ESINHandler::hasAmbiguousDates($this->xml)) {
+//     if (ESINHandler::hasAmbiguousDates($this->xml)) {
+//   All date errors (not just ambiguous dates) have to be fixed - changed Nov 2021 by Janet Bjorndahl
+     if (ESINHandler::hasInvalidDates($this->xml)) {
         return false;
      }
      if (!StructuredData::isRedirect($textbox1)) {


### PR DESCRIPTION
Require all invalid dates (not just ambiguous ones) to be fixed. Message on preview if events out of order (but allow page to be saved). Message on Family page for automatically reformatted dates (missed last year when done on Person page).