### PR TITLE
Prevent wildcard characters in user and tree names; urlencode tree name

### DIFF
--- a/extensions/familytree/FamilyTreeUtil.php
+++ b/extensions/familytree/FamilyTreeUtil.php
@@ -155,7 +155,8 @@ class FamilyTreeUtil {
    }
 
    public static function isValidTreeName($treeName) {
-     return mb_strpos($treeName, '|') === false && $treeName != '[new]' && strlen(trim($treeName)) > 0;
+     // Tree name can't have | or search wildcard (* or ?) in it's name (wildcards added Nov 2021 by Janet Bjorndahl)
+     return preg_match("(\||\*|\?)", $treeName) === 0 && $treeName != '[new]' && strlen(trim($treeName)) > 0;
    }
 
    public static function toInputName($name) {

--- a/extensions/familytree/SpecialCopyTree.php
+++ b/extensions/familytree/SpecialCopyTree.php
@@ -5,6 +5,8 @@
  * @subpackage SpecialPage
  */
 
+/* Written Dec 2020 by Janet Bjorndahl to replace FTE flash functionality */
+
 # Register with MediaWiki as an extension
 $wgExtensionFunctions[] = "wfSpecialCopyTreeSetup";
 
@@ -47,13 +49,18 @@ function wfSpecialCopyTree() {
   // If user has already entered the tree name, copy the tree and display message. Else display the input form.
   $wgOut->setPagetitle("Copy Tree");
   if ( $newName ) {
-    $status = wfCopyFamilyTree("user=$user|name=$name|newuser=$newUser|newname=$newName");
-    if ($status != '<copy status="' . FTE_SUCCESS . '"></copy>') {
-      $msg = htmlspecialchars("Error copying tree $user/$name");
-    }
-	  else {
-      $msg = htmlspecialchars("Tree $user/$name is being copied to $newUser/$newName");
+  	if (!FamilyTreeUtil::isValidTreeName($newName)) {        // added Nov 2021 by Janet Bjorndahl
+      $msg = $newName . ' is not a valid tree name';
 	  }
+    else {
+      $status = wfCopyFamilyTree("user=$user|name=$name|newuser=$newUser|newname=$newName");
+      if ($status != '<copy status="' . FTE_SUCCESS . '"></copy>') {
+        $msg = htmlspecialchars("Error copying tree $user/$name");
+      }
+	    else {
+        $msg = htmlspecialchars("Tree $user/$name is being copied to $newUser/$newName");
+	    }
+    }
 	  $wgOut->addHTML( "<p><font size=\"+1\" color=\"red\">$msg</font></p>\n");
   }
   else {

--- a/extensions/other/SpecialTrees.php
+++ b/extensions/other/SpecialTrees.php
@@ -177,13 +177,13 @@ class SpecialTrees {
    private function emailTree() {
    	global $wrHostName, $wrProtocol, $wgLang, $wgUser, $IP;
 
-    // Link is to explore function that replaced FTE (changed Dec 2020 Janet Bjorndahl)
+    // Link is to explore function that replaced FTE (changed Dec 2020 Janet Bjorndahl; urlencoding added Nov 2021)
     $firstTitle = SpecialTrees::getExploreFirstTitle($wgUser->getName(), $this->name);
-   	$exploreLink = $wrProtocol.'://'.$wrHostName.'/w/index.php?title=' . $firstTitle->getPrefixedURL(). '&mode=explore&user=' . $wgUser->getName() . '&tree='
-                      . str_replace(' ','+',$this->name) . '&liststart=0&listrows=20';
-   	// Added link to allow recipient to copy the tree (Dec 2020 by Janet Bjorndahl)
-    $copyLink = $wrProtocol.'://'.$wrHostName.'/w/index.php?title=Special:CopyTree&user=' . $wgUser->getname() . '&name='
-                      . str_replace(' ','+',$this->name);
+   	$exploreLink = $wrProtocol.'://'.$wrHostName.'/w/index.php?title=' . $firstTitle->getPrefixedURL(). '&mode=explore&user=' . urlencode($wgUser->getName())
+                      . '&tree=' . urlencode($this->name) . '&liststart=0&listrows=20';
+   	// Added link to allow recipient to copy the tree (Dec 2020 by Janet Bjorndahl; urlencoding added Nov 2021)
+    $copyLink = $wrProtocol.'://'.$wrHostName.'/w/index.php?title=Special:CopyTree&user=' . urlencode($wgUser->getname()) 
+                      . '&name=' . urlencode($this->name);
 
 /*    
    	$link = $wrProtocol.'://'.$wrHostName.'/fte/index.php?userName='. urlencode($wgUser->getName()) . '&treeName=' . urlencode($this->name);
@@ -395,7 +395,8 @@ class SpecialTrees {
      $dbr->freeResult($rows);
 
      $firstTitle = $this->getExploreFirstTitle($this->user, $this->name);
-     $wgOut->redirect('http://'.$wrHostName.'/w/index.php?title=' . $firstTitle->getPrefixedURL(). '&mode=explore&user=' . $this->user. '&tree=' . $this->name . '&liststart=0&listrows=20');
+     $wgOut->redirect('http://'.$wrHostName.'/w/index.php?title=' . $firstTitle->getPrefixedURL(). '&mode=explore&user=' . urlencode($this->user)
+           . '&tree=' . urlencode($this->name) . '&liststart=0&listrows=20');      // urlencoding added Nov 2021 by Janet Bjorndahl
    }
    
    private function showInputForm($title, $field, $submitName, $submitValue) {

--- a/includes/SpecialUserlogin.php
+++ b/includes/SpecialUserlogin.php
@@ -225,6 +225,12 @@ class LoginForm {
 			return;
 		}
 
+    // WERELATE - prevent use of search wildcard in user name (wildcard in user name prevents searching the user's trees)
+    if ( preg_match("(\*|\?)", $this->mName) ) {            // added Nov 2021 by Janet Bjorndahl
+			$this->mainLoginForm( wfMsg( 'userwildcard' ) );
+			return false;
+		}
+
 		$name = trim( $this->mName );
 		$u = User::newFromName( $name );
 		if ( is_null( $u ) || in_array( $u->getName(), $wgReservedUsernames ) ) {

--- a/languages/Messages.php
+++ b/languages/Messages.php
@@ -2092,6 +2092,7 @@ Please confirm that really want to recreate this page.',
 'treeupdate' => 'Trees',
 'treeupdatebutton' => 'Update',
 'userprofile' => 'User Profile',
+'userwildcard' => 'User name cannot include a search wildcard (*,?)',    // added Nov 2021 by Janet Bjorndahl
 'watercooler' => 'Watercooler'
 );
 


### PR DESCRIPTION
Prevent wildcard characters (* and ?) in user and tree names because it prevents the user from searching their tree.
Added urlencoding for emailing tree link and exploring tree from GEDCOM import message.