### PR TITLE
SpecialDataQuality - tweaks to capturing comments

### DIFF
--- a/extensions/other/MiscAjaxFunctions.php
+++ b/extensions/other/MiscAjaxFunctions.php
@@ -49,6 +49,7 @@ function wfAddVerifiedTemplate() {
   $pageId = $wgRequest->getVal('pid'); 
   $callback = $wgRequest->getVal('callback');
   $desc = urldecode($wgRequest->getVal('desc'));
+  $comments = urldecode($wgRequest->getVal('comments'));
   $addWatches = $wgUser->getOption( 'watchdefault' );
 
   $pageTitle = Title::newFromText($titleString, $namespace);
@@ -59,7 +60,8 @@ function wfAddVerifiedTemplate() {
 	  if ($targetTalkContents) {
 			$targetTalkContents = rtrim($targetTalkContents) . "\n\n";
 		}
-		$success = $article->doEdit($targetTalkContents . '{{' . $templateName . '|' . date("j M Y") . '|[[User:' . $wgUser->getName() . '|' . $wgUser->getName() . ']]}}', "Add $templateName template");
+		$success = $article->doEdit($targetTalkContents . '{{' . $templateName . '|' . date("j M Y") . '|[[User:' . $wgUser->getName() . '|' . $wgUser->getName() . ']]|' . 
+                $comments . '}}', "Add $templateName template");
     if ($success) {
 		  if ($addWatches) {
    		  StructuredData::addWatch($wgUser, $article, true);

--- a/extensions/other/SpecialDataQuality.php
+++ b/extensions/other/SpecialDataQuality.php
@@ -175,7 +175,7 @@ class DataQuality {
 		  $dbr->freeResult( $res );
     } 
 
- 		$wgOut->addScript("<script type=\"text/javascript\" src=\"$wgScriptPath/report.2.js\"></script>");
+ 		$wgOut->addScript("<script type=\"text/javascript\" src=\"$wgScriptPath/report.3.js\"></script>");
 
     $parmForm = '<form method="get" action="/wiki/' . $this->selfTitle->getPrefixedURL() . '">';
     $parmForm .= '<table class="parmform"><tr><td><label for="category">Category: </label>';
@@ -441,7 +441,7 @@ class DataQuality {
           $wgOut->addHTML( '<td><span class="attn">Deferred</span></td>');
         }  
         else {
-          $wgOut->addHTML( '<td><input type="button" id="defer' . $rowNum . '" title="Do not show me this issue again until I request to see hidden issues." value="' . 
+          $wgOut->addHTML( '<td><input type="button" id="defer' . $rowNum . '" title="Mark this issue as deferred so that you can ignore it for now." value="' . 
                   wfMsgExt( 'deferissue', array( 'escape') ) . 
                   '" onClick="addDeferredTemplate(' . $rowNum . ',' . $row->dq_page_id . ',' . $row->page_namespace . ',\'' . $row->page_title . '\')" /></td>' );
         }      

--- a/report.js
+++ b/report.js
@@ -10,25 +10,33 @@ function toggleEnabled(checkId, checkValue, toggleId) {
 
 /* Add a template to a Talk page to indicate that an anomaly has been verified. The Talk page will be created if it doesn't already exist. */
 function addVerifiedTemplate(rowNum, pageId, ns, title, template, desc) {
-	$.getJSON('/w/index.php?action=ajax&rs=wfAddVerifiedTemplate&pid=' + pageId + '&ns=' + ns + '&title=' + title + '&template=' + template + '&desc=' + desc + '&callback=?', function(success) {
-     if (success) {
-       $('#' + 'verify' + rowNum).replaceWith('<span class="attn">&nbsp;Marked verified</span>');
-     }
-     else {
-       $('#' + 'verify' + rowNum).replaceWith('<span class="attn">&nbsp;Failed</span>');
-     }
-  })
+  var comments = encodeURIComponent(prompt("Enter any comments you wish to leave on the Talk page", "none")); 
+  // If user selected "cancel" (comments = 'null'), don't proceed with the template
+  if ( comments !== 'null' ) {
+	  $.getJSON('/w/index.php?action=ajax&rs=wfAddVerifiedTemplate&pid=' + pageId + '&ns=' + ns + '&title=' + title + '&template=' + template + '&desc=' + desc +
+          '&comments=' + comments + '&callback=?', function(success) {
+      if (success) {
+        $('#' + 'verify' + rowNum).replaceWith('<span class="attn">&nbsp;Marked verified</span>');
+      }  
+      else {
+        $('#' + 'verify' + rowNum).replaceWith('<span class="attn">&nbsp;Failed</span>');
+      }
+    })
+  }  
 }
 
-/* Add a template to a Talk page to indicate that the user doesn't want to see the Person/Family page on the DQ report for now. The Talk page will be created if it doesn't already exist. */
+/* Add a template to a Talk page to indicate that the user has defered resolution of issues on a Person/Family page for now. The Talk page will be created if it doesn't already exist. */
 function addDeferredTemplate(rowNum, pageId, ns, title) {
-  var comments = encodeURIComponent(prompt("Do you wish to leave comments on the Talk page?", "none")); 
-	$.getJSON('/w/index.php?action=ajax&rs=wfAddDeferredTemplate&pid=' + pageId + '&ns=' + ns + '&title=' + title + '&comments=' + comments + '&callback=?', function(success) {
-     if (success) {
-       $('#' + 'defer' + rowNum).replaceWith('<span class="attn">&nbsp;Deferred</span>');
-     }
-     else {
-       $('#' + 'defer' + rowNum).replaceWith('<span class="attn">&nbsp;Failed</span>');
-     }
-  })
+  var comments = encodeURIComponent(prompt("Enter any comments you wish to leave on the Talk page", "none")); 
+  // If user selected "cancel" (comments = 'null'), don't proceed with the template
+  if ( comments !== 'null' ) {
+	  $.getJSON('/w/index.php?action=ajax&rs=wfAddDeferredTemplate&pid=' + pageId + '&ns=' + ns + '&title=' + title + '&comments=' + comments + '&callback=?', function(success) {
+      if (success) {
+        $('#' + 'defer' + rowNum).replaceWith('<span class="attn">&nbsp;Deferred</span>');
+      }
+      else {
+        $('#' + 'defer' + rowNum).replaceWith('<span class="attn">&nbsp;Failed</span>');
+      }
+    })   
+  }
 }


### PR DESCRIPTION
Capture user comments when verifying an anomaly.
When prompting for user comments, allow user to cancel the action (don't add the template).